### PR TITLE
Refactor integrations into services and add cron jobs

### DIFF
--- a/app/blueprints/cron.py
+++ b/app/blueprints/cron.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import datetime as dt
+
+from flask import Blueprint, jsonify, request
+
+from app.services.culture_amp import export_culture_amp_snapshot
+from app.services.runn_sync import sync_runn_onboarding, sync_runn_timeoff
+
+bp_cron = Blueprint("cron", __name__)
+
+
+@bp_cron.route("/cron/nightly", methods=["GET"])
+def nightly():
+    try:
+        result = export_culture_amp_snapshot()
+        return jsonify({"status": "ok", "result": result})
+    except Exception as exc:  # pragma: no cover - logging
+        print("nightly export error:", repr(exc))
+        return jsonify({"status": "error", "message": str(exc)}), 500
+
+
+@bp_cron.route("/cron/runn/onboarding", methods=["GET"])
+def runn_onboarding():
+    ref = request.args.get("date")
+    reference = None
+    if ref:
+        try:
+            reference = dt.datetime.strptime(ref, "%Y-%m-%d").date()
+        except ValueError:
+            reference = None
+    result = sync_runn_onboarding(reference)
+    return jsonify(result)
+
+
+@bp_cron.route("/cron/runn/timeoff", methods=["GET"])
+def runn_timeoff():
+    ref = request.args.get("date")
+    reference = None
+    if ref:
+        try:
+            reference = dt.datetime.strptime(ref, "%Y-%m-%d").date()
+        except ValueError:
+            reference = None
+    result = sync_runn_timeoff(reference)
+    return jsonify(result)

--- a/app/blueprints/teamtailor_webhook.py
+++ b/app/blueprints/teamtailor_webhook.py
@@ -1,7 +1,7 @@
 from flask import Blueprint, request
 from app.utils.config import tt_verify_signature
-from app.clients.teamtailor import tt_fetch_application, tt_get_offer_start_date_for_application
-from app.clients.charthop import ch_import_people_csv
+from app.clients.teamtailor import tt_fetch_application
+from app.services.hire import process_hired_application
 
 bp_tt = Blueprint("teamtailor_webhook", __name__)
 
@@ -26,38 +26,8 @@ def tt_webhook():
             return "", 200
 
         body = resp.json() or {}
-        data = body.get("data") or {}
-        attributes = data.get("attributes") or {}
-        status = (attributes.get("status") or attributes.get("state") or "").lower()
-        hired_at = attributes.get("hired-at") or attributes.get("hired_at")
-
-        if status != "hired" and not hired_at:
-            print("TT webhook: application not hired, skipping"); return "", 200
-
-        included = body.get("included") or []
-        cand = next((i for i in included if i.get("type") == "candidates"), {}) or {}
-        job  = next((i for i in included if i.get("type") == "jobs"), {}) or {}
-
-        cand_attr = cand.get("attributes") or {}
-        job_attr  = job.get("attributes") or {}
-
-        first = cand_attr.get("first-name") or cand_attr.get("first_name") or ""
-        last  = cand_attr.get("last-name") or cand_attr.get("last_name") or ""
-        personal_email = cand_attr.get("email") or ""
-        title = job_attr.get("title") or ""
-
-        # Start date desde Offer
-        start_date = tt_get_offer_start_date_for_application(rid) or (attributes.get("start-date") or attributes.get("start_date") or (hired_at or ""))[:10]
-
-        rows = [{
-            "contact personalemail": personal_email,
-            "first name": first,
-            "last name": last,
-            "title": title,
-            "start date": start_date or ""
-        }]
-        ch_import_people_csv(rows)
-        print("CH import ok")
+        result = process_hired_application(rid, body)
+        print("TT hire result:", result)
         return "", 200
 
     except Exception as e:

--- a/app/clients/charthop.py
+++ b/app/clients/charthop.py
@@ -1,40 +1,272 @@
-import io, csv, requests
-from . import __init__  # noqa
-from app.utils.config import CH_API, CH_ORG_ID, ch_headers, HTTP_TIMEOUT
+import csv
+import io
+from datetime import date, datetime
+from typing import Dict, Iterable, Iterator, List, Optional
 
-def ch_find_job(job_id: str):
-    url = f"{CH_API}/v2/org/{CH_ORG_ID}/job"
-    params = {"q": f"jobid\\{job_id}", "fields": "title,department name,location name,open"}
-    r = requests.get(url, headers=ch_headers(), params=params, timeout=HTTP_TIMEOUT)
+import requests
+
+from app.utils.config import (
+    CH_API,
+    CH_CF_JOB_TT_ID_LABEL,
+    CH_ORG_ID,
+    CORP_EMAIL_DOMAIN,
+    AUTO_ASSIGN_WORK_EMAIL,
+    HTTP_TIMEOUT,
+    ch_headers,
+    compose_location,
+    derive_locale_timezone,
+    strip_accents_and_non_alnum,
+)
+
+
+def ch_find_job(job_id: str, fields: Optional[str] = None) -> Optional[Dict]:
+    """Busca un Job por jobid usando el filtro q=jobid\\{id}."""
+    params: Dict[str, str] = {"q": f"jobid\\{job_id}"}
+    default_fields = ["title", "department name", "location name", "open"]
+    if CH_CF_JOB_TT_ID_LABEL:
+        default_fields.append(CH_CF_JOB_TT_ID_LABEL)
+    params["fields"] = fields or ",".join(default_fields)
+    try:
+        r = requests.get(
+            f"{CH_API}/v2/org/{CH_ORG_ID}/job",
+            headers=ch_headers(),
+            params=params,
+            timeout=HTTP_TIMEOUT,
+        )
+    except Exception as exc:  # pragma: no cover - logging
+        print("ch_find_job error:", repr(exc))
+        return None
     if not r.ok:
         print("ch_find_job status:", r.status_code, (r.text or "")[:200])
         return None
     items = (r.json() or {}).get("data") or []
     return items[0] if items else None
 
+
 def ch_upsert_job_field(job_id: str, field_label: str, value: str):
     sio = io.StringIO()
-    w = csv.DictWriter(sio, fieldnames=["job id", field_label])
-    w.writeheader()
-    w.writerow({"job id": job_id, field_label: value})
+    writer = csv.DictWriter(sio, fieldnames=["job id", field_label])
+    writer.writeheader()
+    writer.writerow({"job id": job_id, field_label: value})
     sio.seek(0)
     files = {"file": ("jobs.csv", sio.read())}
     url = f"{CH_API}/v1/org/{CH_ORG_ID}/import/csv/data"
     params = {"upsert": "true"}
-    r = requests.post(url, headers=ch_headers(), params=params, files=files, timeout=HTTP_TIMEOUT)
+    r = requests.post(
+        url,
+        headers=ch_headers(),
+        params=params,
+        files=files,
+        timeout=HTTP_TIMEOUT,
+    )
     r.raise_for_status()
     return r.json()
 
-def ch_import_people_csv(rows):
+
+def ch_import_people_csv(rows: List[Dict]):
     if not rows:
         return {"status": "empty"}
     output = io.StringIO()
     writer = csv.DictWriter(output, fieldnames=rows[0].keys())
-    writer.writeheader(); writer.writerows(rows); output.seek(0)
+    writer.writeheader()
+    writer.writerows(rows)
+    output.seek(0)
     files = {"file": ("people.csv", output.read())}
     url = f"{CH_API}/v1/org/{CH_ORG_ID}/import/csv/data"
     params = {"upsert": "true", "creategroups": "true"}
-    r = requests.post(url, headers=ch_headers(), params=params, files=files, timeout=HTTP_TIMEOUT)
+    r = requests.post(
+        url,
+        headers=ch_headers(),
+        params=params,
+        files=files,
+        timeout=HTTP_TIMEOUT,
+    )
     r.raise_for_status()
     return r.json()
 
+
+def ch_email_exists(email: str) -> bool:
+    if not email:
+        return False
+    try:
+        url = f"{CH_API}/v2/org/{CH_ORG_ID}/person"
+        params = {"q": f"contact workemail\\{email}", "fields": "contact workemail"}
+        r = requests.get(url, headers=ch_headers(), params=params, timeout=HTTP_TIMEOUT)
+        if not r.ok:
+            return False
+        for item in (r.json() or {}).get("data", []):
+            fields = item.get("fields") or {}
+            work = (fields.get("contact workemail") or "").strip().lower()
+            if work == email.strip().lower():
+                return True
+    except Exception as exc:  # pragma: no cover - logging
+        print("ch_email_exists error:", repr(exc))
+    return False
+
+
+def generate_unique_work_email(first: str, last: str) -> Optional[str]:
+    if not AUTO_ASSIGN_WORK_EMAIL or not CORP_EMAIL_DOMAIN:
+        return None
+    base_local = f"{strip_accents_and_non_alnum(first)}{strip_accents_and_non_alnum(last)}"
+    if not base_local:
+        return None
+    candidate = f"{base_local}@{CORP_EMAIL_DOMAIN}"
+    if not ch_email_exists(candidate):
+        return candidate
+    for i in range(2, 100):
+        candidate = f"{base_local}{i}@{CORP_EMAIL_DOMAIN}"
+        if not ch_email_exists(candidate):
+            return candidate
+    return None
+
+
+def ch_iter_people(fields: str, limit: int = 200) -> Iterator[Dict]:
+    offset = 0
+    while True:
+        params = {"fields": fields, "limit": limit, "offset": offset}
+        try:
+            r = requests.get(
+                f"{CH_API}/v2/org/{CH_ORG_ID}/person",
+                headers=ch_headers(),
+                params=params,
+                timeout=HTTP_TIMEOUT,
+            )
+            r.raise_for_status()
+        except Exception as exc:  # pragma: no cover - logging
+            print("ch_iter_people error:", repr(exc))
+            return
+        payload = r.json() or {}
+        data = payload.get("data") or []
+        if not data:
+            return
+        for item in data:
+            yield item
+        offset += len(data)
+
+
+def ch_active_people(fields: str) -> List[Dict]:
+    rows: List[Dict] = []
+    for item in ch_iter_people(fields):
+        fields_map = item.get("fields") or {}
+        status = (fields_map.get("status") or "").strip().lower()
+        if status and status not in {"active", "current", "enabled"}:
+            continue
+        rows.append(item)
+    return rows
+
+
+def ch_people_starting_between(start: date, end: date, fields: Optional[str] = None) -> List[Dict]:
+    fields = fields or "person id,name first,name last,contact workemail,contact personalemail,start date,title"
+    people = []
+    for item in ch_active_people(fields + ",status"):
+        flds = item.get("fields") or {}
+        start_raw = (flds.get("start date") or flds.get("startdate") or "").strip()
+        if not start_raw:
+            continue
+        try:
+            start_dt = datetime.strptime(start_raw[:10], "%Y-%m-%d").date()
+        except ValueError:
+            continue
+        if start <= start_dt <= end:
+            people.append(item)
+    return people
+
+
+def ch_fetch_timeoff(start: date, end: date) -> List[Dict]:
+    url = f"{CH_API}/v2/org/{CH_ORG_ID}/timeoff"
+    params = {
+        "startDate": start.isoformat(),
+        "endDate": end.isoformat(),
+        "fields": "person id,person name,person contact workemail,start date,end date,type,reason,status",
+    }
+    try:
+        r = requests.get(url, headers=ch_headers(), params=params, timeout=HTTP_TIMEOUT)
+        if not r.ok:
+            print("ch_fetch_timeoff status:", r.status_code, (r.text or "")[:200])
+            return []
+        payload = r.json() or {}
+        data = payload.get("data")
+        if isinstance(data, list):
+            return data
+        if isinstance(data, dict):
+            return [data]
+    except Exception as exc:  # pragma: no cover - logging
+        print("ch_fetch_timeoff error:", repr(exc))
+    return []
+
+
+def build_culture_amp_rows() -> List[Dict[str, str]]:
+    fields = ",".join(
+        [
+            "person id",
+            "name first",
+            "name last",
+            "preferred name first",
+            "contact workemail",
+            "contact personalemail",
+            "manager contact workemail",
+            "title",
+            "seniority",
+            "homeaddress country",
+            "homeaddress region",
+            "status",
+        ]
+    )
+    rows: List[Dict[str, str]] = []
+    for person in ch_active_people(fields):
+        flds = person.get("fields") or {}
+        work = (flds.get("contact workemail") or "").strip()
+        if not work:
+            continue
+        preferred = flds.get("preferred name first") or ""
+        first = preferred or (flds.get("name first") or "")
+        last = flds.get("name last") or ""
+        name = " ".join(part for part in [first, last] if part).strip()
+        country = flds.get("homeaddress country") or ""
+        region = flds.get("homeaddress region") or ""
+        locale, timezone = derive_locale_timezone(country)
+        rows.append(
+            {
+                "Employee Id": flds.get("person id") or work,
+                "Email": work,
+                "Name": name,
+                "Preferred Name": preferred,
+                "Manager Email": flds.get("manager contact workemail") or "",
+                "Location": compose_location(region, country),
+                "Job Title": flds.get("title") or "",
+                "Seniority": flds.get("seniority") or "",
+                "Locale": locale,
+                "Timezone": timezone,
+            }
+        )
+    return rows
+
+
+def culture_amp_csv_from_rows(rows: Iterable[Dict[str, str]]) -> str:
+    columns = [
+        "Employee Id",
+        "Email",
+        "Name",
+        "Preferred Name",
+        "Manager Email",
+        "Location",
+        "Job Title",
+        "Seniority",
+        "Locale",
+        "Timezone",
+    ]
+    sio = io.StringIO()
+    writer = csv.DictWriter(sio, fieldnames=columns, extrasaction="ignore")
+    writer.writeheader()
+    for row in rows:
+        writer.writerow(row)
+    return sio.getvalue()
+
+
+def ch_person_primary_email(person: Dict) -> Optional[str]:
+    flds = (person or {}).get("fields") or {}
+    work = (flds.get("contact workemail") or "").strip()
+    if work:
+        return work
+    personal = (flds.get("contact personalemail") or "").strip()
+    return personal or None

--- a/app/clients/runn.py
+++ b/app/clients/runn.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from typing import Optional
+
+import requests
+
+from app.utils.config import HTTP_TIMEOUT, RUNN_API, runn_headers
+
+
+def runn_find_person_by_email(email: str) -> Optional[dict]:
+    if not email:
+        return None
+    try:
+        resp = requests.get(
+            f"{RUNN_API}/people",
+            headers=runn_headers(),
+            params={"email": email},
+            timeout=HTTP_TIMEOUT,
+        )
+        if resp.ok and isinstance(resp.json(), list) and resp.json():
+            return (resp.json() or [None])[0]
+    except Exception as exc:  # pragma: no cover - logging
+        print("runn_find_person_by_email error:", repr(exc))
+    return None
+
+
+def runn_upsert_person(
+    *,
+    name: str,
+    email: Optional[str],
+    role_id: Optional[str] = None,
+    team_id: Optional[str] = None,
+    employment_type: Optional[str] = None,
+    starts_at: Optional[str] = None,
+) -> Optional[dict]:
+    payload: dict = {"name": name}
+    if email:
+        payload["email"] = email
+    if role_id:
+        payload["role_id"] = role_id
+    if team_id:
+        payload["team_id"] = team_id
+    if employment_type:
+        payload["employment_type"] = employment_type
+    if starts_at:
+        payload["starts_at"] = starts_at
+
+    try:
+        resp = requests.post(
+            f"{RUNN_API}/people",
+            headers=runn_headers(),
+            json=payload,
+            timeout=HTTP_TIMEOUT,
+        )
+        if resp.status_code in (200, 201):
+            return resp.json()
+        if resp.status_code == 409 and email:
+            existing = runn_find_person_by_email(email)
+            if existing and existing.get("id"):
+                person_id = existing["id"]
+                upd = requests.patch(
+                    f"{RUNN_API}/people/{person_id}",
+                    headers=runn_headers(),
+                    json=payload,
+                    timeout=HTTP_TIMEOUT,
+                )
+                if upd.ok:
+                    return {"id": person_id}
+        resp.raise_for_status()
+    except Exception as exc:  # pragma: no cover - logging
+        print("runn_upsert_person error:", repr(exc))
+    return None
+
+
+def runn_create_leave(
+    *,
+    person_id: str,
+    starts_at: str,
+    ends_at: str,
+    reason: str = "Vacation",
+    external_ref: Optional[str] = None,
+) -> Optional[dict]:
+    payload = {"personId": person_id, "startsAt": starts_at, "endsAt": ends_at, "reason": reason}
+    if external_ref:
+        payload["externalRef"] = external_ref
+    try:
+        resp = requests.post(
+            f"{RUNN_API}/time-offs/leave",
+            headers=runn_headers(),
+            json=payload,
+            timeout=HTTP_TIMEOUT,
+        )
+        resp.raise_for_status()
+        return resp.json()
+    except Exception as exc:  # pragma: no cover - logging
+        print("runn_create_leave error:", repr(exc))
+    return None

--- a/app/clients/sftp.py
+++ b/app/clients/sftp.py
@@ -1,0 +1,67 @@
+import io
+import os
+import socket
+from typing import Optional
+
+import paramiko
+
+
+def _sftp_ensure_dirs(sftp: paramiko.SFTPClient, remote_dir: str):
+    if not remote_dir or remote_dir == "/":
+        return
+    parts = []
+    for segment in remote_dir.strip("/").split("/"):
+        parts.append(segment)
+        path = "/" + "/".join(parts)
+        try:
+            sftp.stat(path)
+        except FileNotFoundError:
+            sftp.mkdir(path)
+
+
+def sftp_upload(
+    *,
+    host: str,
+    username: str,
+    password: Optional[str] = None,
+    pkey_pem: Optional[str] = None,
+    passphrase: Optional[str] = None,
+    remote_path: str,
+    content: str,
+):
+    if not host or not username:
+        raise RuntimeError("SFTP requiere host y username configurados")
+    sock = socket.create_connection((host.rstrip("."), 22), timeout=15)
+    transport = paramiko.Transport(sock)
+    transport.banner_timeout = 15
+    key = None
+    try:
+        if pkey_pem:
+            buffer = io.StringIO(pkey_pem)
+            try:
+                key = paramiko.Ed25519Key.from_private_key(buffer, password=passphrase)
+            except Exception:
+                buffer.seek(0)
+                key = paramiko.RSAKey.from_private_key(buffer, password=passphrase)
+            transport.connect(username=username, pkey=key)
+        else:
+            if not password:
+                raise RuntimeError("SFTP necesita password o clave privada")
+            transport.connect(username=username, password=password)
+        sftp = paramiko.SFTPClient.from_transport(transport)
+        try:
+            directory = os.path.dirname(remote_path) or "/"
+            _sftp_ensure_dirs(sftp, directory)
+            with sftp.file(remote_path, "wb") as handler:
+                handler.write(content.encode("utf-8"))
+                handler.flush()
+        finally:
+            try:
+                sftp.close()
+            finally:
+                transport.close()
+    finally:
+        try:
+            sock.close()
+        except Exception:  # pragma: no cover - logging
+            pass

--- a/app/services/culture_amp.py
+++ b/app/services/culture_amp.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import datetime as dt
+
+from app.clients.charthop import build_culture_amp_rows, culture_amp_csv_from_rows
+from app.clients.sftp import sftp_upload
+from app.utils.config import (
+    CA_SFTP_HOST,
+    CA_SFTP_KEY,
+    CA_SFTP_PASS,
+    CA_SFTP_PATH,
+    CA_SFTP_PASSPHRASE,
+    CA_SFTP_USER,
+)
+
+
+def export_culture_amp_snapshot() -> dict:
+    rows = build_culture_amp_rows()
+    csv_text = culture_amp_csv_from_rows(rows)
+    if not csv_text or csv_text.count("\n") <= 1:
+        raise RuntimeError("CSV vacío para Culture Amp")
+    if not CA_SFTP_HOST or not CA_SFTP_USER:
+        raise RuntimeError("Credenciales SFTP incompletas para Culture Amp")
+    fname = f"{CA_SFTP_PATH.rstrip('/')}/employees_{dt.date.today().isoformat()}.csv"
+    sftp_upload(
+        host=CA_SFTP_HOST,
+        username=CA_SFTP_USER,
+        password=CA_SFTP_PASS,
+        pkey_pem=CA_SFTP_KEY,
+        passphrase=CA_SFTP_PASSPHRASE,
+        remote_path=fname,
+        content=csv_text,
+    )
+    return {"rows": len(rows), "remote_path": fname}

--- a/app/services/hire.py
+++ b/app/services/hire.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from typing import Dict
+
+from app.clients.charthop import ch_import_people_csv, generate_unique_work_email
+from app.clients.runn import runn_upsert_person
+from app.clients.teamtailor import tt_get_offer_start_date_for_application
+from app.utils.config import RUNN_CREATE_ON_HIRE
+
+
+def _resolve_candidate(included: list, type_name: str) -> Dict:
+    return next((item for item in included if item.get("type") == type_name), {}) or {}
+
+
+def _extract_name(attributes: Dict, field: str) -> str:
+    return attributes.get(field) or attributes.get(field.replace("-", "_")) or ""
+
+
+def process_hired_application(app_id: str, payload: Dict) -> Dict:
+    data = payload.get("data") or {}
+    attributes = data.get("attributes") or {}
+    status = (attributes.get("status") or attributes.get("state") or "").lower()
+    hired_at = attributes.get("hired-at") or attributes.get("hired_at") or ""
+    if status != "hired" and not hired_at:
+        return {"processed": False, "reason": "application not hired"}
+
+    included = payload.get("included") or []
+    candidate = _resolve_candidate(included, "candidates")
+    job = _resolve_candidate(included, "jobs")
+
+    cand_attr = candidate.get("attributes") or {}
+    job_attr = job.get("attributes") or {}
+
+    first = _extract_name(cand_attr, "first-name")
+    last = _extract_name(cand_attr, "last-name")
+    personal_email = cand_attr.get("email") or ""
+    title = job_attr.get("title") or ""
+
+    start_date = tt_get_offer_start_date_for_application(app_id, payload) or (
+        attributes.get("start-date")
+        or attributes.get("start_date")
+        or (hired_at or "")[:10]
+    )
+
+    work_email = generate_unique_work_email(first, last)
+
+    row = {
+        "first name": first,
+        "last name": last,
+        "contact personalemail": personal_email,
+        "title": title,
+        "start date": start_date or "",
+    }
+    if work_email:
+        row["contact workemail"] = work_email
+
+    ch_result = ch_import_people_csv([row])
+
+    runn_result = None
+    email_for_runn = work_email or personal_email or None
+    if RUNN_CREATE_ON_HIRE and email_for_runn:
+        runn_result = runn_upsert_person(
+            name=f"{first} {last}".strip(),
+            email=email_for_runn,
+            employment_type="employee",
+            starts_at=start_date,
+        )
+
+    return {
+        "processed": True,
+        "chartHopImport": ch_result,
+        "generatedWorkEmail": work_email,
+        "runnResult": runn_result,
+    }

--- a/app/services/job_sync.py
+++ b/app/services/job_sync.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from app.clients.charthop import ch_find_job, ch_upsert_job_field
+from app.clients.teamtailor import (
+    tt_create_job_from_ch,
+    tt_update_job,
+    tt_upsert_job_custom_field,
+)
+from app.utils.config import CH_CF_JOB_TT_ID_LABEL
+
+
+def _extract_job_title(job_payload: dict) -> str:
+    title = job_payload.get("title") or ""
+    if title:
+        return title
+    fields = job_payload.get("fields") or {}
+    return fields.get("title") or fields.get("name") or "Untitled"
+
+
+def _extract_job_open(job_payload: dict) -> Optional[bool]:
+    if "open" in job_payload:
+        return bool(job_payload.get("open"))
+    fields = job_payload.get("fields") or {}
+    if "open" in fields:
+        return bool(fields.get("open"))
+    return None
+
+
+def _status_from_open(is_open: Optional[bool]) -> Optional[str]:
+    if is_open is None:
+        return None
+    return "unlisted" if is_open else "archived"
+
+
+def sync_job_create(job_id: str) -> Optional[str]:
+    job = ch_find_job(job_id)
+    if not job:
+        print(f"sync_job_create: job {job_id} not found in ChartHop")
+        return None
+
+    title = _extract_job_title(job)
+    status = _status_from_open(_extract_job_open(job)) or "unlisted"
+    resp = tt_create_job_from_ch(title=title, status=status)
+    print("sync_job_create TT status:", resp.status_code)
+    if not resp.ok:
+        return None
+    tt_job_id = ((resp.json() or {}).get("data") or {}).get("id")
+    if not tt_job_id:
+        return None
+    try:
+        tt_upsert_job_custom_field(tt_job_id, job_id)
+    except Exception as exc:  # pragma: no cover - logging
+        print("sync_job_create: failed linking TT custom field", repr(exc))
+    if CH_CF_JOB_TT_ID_LABEL:
+        try:
+            ch_upsert_job_field(job_id, CH_CF_JOB_TT_ID_LABEL, tt_job_id)
+        except Exception as exc:  # pragma: no cover - logging
+            print("sync_job_create: failed writing TT id back to ChartHop", repr(exc))
+    return tt_job_id
+
+
+def sync_job_update(job_id: str) -> bool:
+    job = ch_find_job(job_id)
+    if not job:
+        print(f"sync_job_update: job {job_id} not found in ChartHop")
+        return False
+    fields = job.get("fields") or {}
+    tt_job_id = (fields.get(CH_CF_JOB_TT_ID_LABEL) or "").strip() if CH_CF_JOB_TT_ID_LABEL else ""
+    if not tt_job_id:
+        print(f"sync_job_update: job {job_id} without TT mapping, skipping")
+        return False
+    title = _extract_job_title(job)
+    status = _status_from_open(_extract_job_open(job))
+    resp = tt_update_job(tt_job_id, title=title, status=status)
+    if resp is None:
+        print(f"sync_job_update: nothing to update for job {tt_job_id}")
+        return True
+    print("sync_job_update TT status:", resp.status_code)
+    return resp.ok

--- a/app/services/runn_sync.py
+++ b/app/services/runn_sync.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import datetime as dt
+from typing import Dict, List
+
+from app.clients.charthop import (
+    ch_fetch_timeoff,
+    ch_people_starting_between,
+    ch_person_primary_email,
+)
+from app.clients.runn import runn_create_leave, runn_find_person_by_email, runn_upsert_person
+from app.utils.config import (
+    RUNN_ONBOARDING_LOOKAHEAD_DAYS,
+    RUNN_TIMEOFF_LOOKAHEAD_DAYS,
+    RUNN_TIMEOFF_LOOKBACK_DAYS,
+)
+
+
+def _safe_date(value: str) -> str:
+    if not value:
+        return ""
+    return value[:10]
+
+
+def sync_runn_onboarding(reference: dt.date | None = None) -> Dict:
+    reference = reference or dt.date.today()
+    end = reference + dt.timedelta(days=RUNN_ONBOARDING_LOOKAHEAD_DAYS)
+    people = ch_people_starting_between(reference, end)
+    results: List[Dict] = []
+    for person in people:
+        fields = person.get("fields") or {}
+        name = " ".join(
+            part
+            for part in [fields.get("name first"), fields.get("name last")]
+            if part
+        ).strip() or fields.get("name") or ""
+        email = ch_person_primary_email(person)
+        start_date = _safe_date(fields.get("start date") or fields.get("startdate") or "")
+        if not email:
+            results.append({"person": name, "status": "skipped", "reason": "missing email"})
+            continue
+        runn_resp = runn_upsert_person(
+            name=name or email,
+            email=email,
+            employment_type=fields.get("employment type") or "employee",
+            starts_at=start_date or reference.isoformat(),
+        )
+        results.append({"person": name or email, "status": "created" if runn_resp else "error", "response": runn_resp})
+    return {"processed": len(people), "results": results}
+
+
+def _timeoff_reason(entry: Dict) -> str:
+    fields = entry.get("fields") or {}
+    raw_reason = (fields.get("reason") or entry.get("reason") or "").lower()
+    raw_type = (fields.get("type") or entry.get("type") or "").lower()
+    text = raw_reason or raw_type
+    if "sick" in text:
+        return "Sick leave"
+    if "pto" in text or "vacation" in text:
+        return "Vacation"
+    if "bereavement" in text:
+        return "Bereavement"
+    return "Leave"
+
+
+def sync_runn_timeoff(reference: dt.date | None = None) -> Dict:
+    reference = reference or dt.date.today()
+    start = reference - dt.timedelta(days=RUNN_TIMEOFF_LOOKBACK_DAYS)
+    end = reference + dt.timedelta(days=RUNN_TIMEOFF_LOOKAHEAD_DAYS)
+    events = ch_fetch_timeoff(start, end)
+    results: List[Dict] = []
+    for entry in events:
+        fields = entry.get("fields") or {}
+        email = (fields.get("person contact workemail") or fields.get("contact workemail") or "").strip()
+        if not email:
+            email = (fields.get("person contact personalemail") or "").strip()
+        if not email:
+            results.append({"status": "skipped", "reason": "missing email", "entry": entry})
+            continue
+        person = runn_find_person_by_email(email)
+        if not person or not person.get("id"):
+            results.append({"status": "skipped", "reason": "person not found", "email": email})
+            continue
+        start_date = _safe_date(fields.get("start date") or entry.get("startDate") or "")
+        end_date = _safe_date(fields.get("end date") or entry.get("endDate") or start_date)
+        if not start_date:
+            results.append({"status": "skipped", "reason": "missing start date", "email": email})
+            continue
+        reason = _timeoff_reason(entry)
+        resp = runn_create_leave(
+            person_id=person["id"],
+            starts_at=start_date,
+            ends_at=end_date or start_date,
+            reason=reason,
+            external_ref=str(entry.get("id") or fields.get("id") or ""),
+        )
+        results.append({"status": "synced" if resp else "error", "email": email, "response": resp})
+    return {"processed": len(events), "results": results}

--- a/app/utils/config.py
+++ b/app/utils/config.py
@@ -1,31 +1,129 @@
-import os, hmac, hashlib, base64
+import os
+import hmac
+import hashlib
+import base64
+import unicodedata
+from typing import Tuple
 
+
+HTTP_TIMEOUT = int(os.getenv("HTTP_TIMEOUT", "30"))
+
+
+# =========================
+# ChartHop
+# =========================
 CH_API = os.getenv("CH_API", "https://api.charthop.com")
 CH_ORG_ID = os.getenv("CH_ORG_ID")
 CH_API_TOKEN = os.getenv("CH_API_TOKEN")
+DEFAULT_LOCALE = os.getenv("DEFAULT_LOCALE", "es-LA")
+DEFAULT_TIMEZONE = os.getenv("DEFAULT_TIMEZONE", "UTC")
+CORP_EMAIL_DOMAIN = os.getenv("CORP_EMAIL_DOMAIN")
+AUTO_ASSIGN_WORK_EMAIL = os.getenv("AUTO_ASSIGN_WORK_EMAIL", "false").lower() in ("1", "true", "yes", "on")
 
+# Custom fields para sincronizar IDs cruzados
+TT_CF_JOB_CH_ID = os.getenv("TT_CF_JOB_CH_ID")
+TT_CF_JOB_CH_API_NAME = os.getenv("TT_CF_JOB_CH_API_NAME", "charthop-job-id")
+CH_CF_JOB_TT_ID_LABEL = os.getenv("CH_CF_JOB_TT_ID_LABEL", "teamtailorJobid")
+
+
+# =========================
+# Teamtailor
+# =========================
 TT_API = os.getenv("TT_API", "https://api.teamtailor.com/v1")
 TT_API_KEY = os.getenv("TT_API_KEY") or os.getenv("TEAMTAILOR_API_KEY")
 TT_API_VERSION = os.getenv("TT_API_VERSION", "20240404")
 TT_SIGNATURE_KEY = os.getenv("TT_SIGNATURE_KEY")
 
-HTTP_TIMEOUT = int(os.getenv("HTTP_TIMEOUT", "30"))
 
-TT_CF_JOB_CH_ID = os.getenv("TT_CF_JOB_CH_ID")
-TT_CF_JOB_CH_API_NAME = os.getenv("TT_CF_JOB_CH_API_NAME", "charthop-job-id")
-CH_CF_JOB_TT_ID_LABEL = os.getenv("CH_CF_JOB_TT_ID_LABEL", "teamtailorJobid")
+# =========================
+# Runn
+# =========================
+RUNN_API = os.getenv("RUNN_API", "https://api.runn.io")
+RUNN_API_TOKEN = os.getenv("RUNN_API_TOKEN")
+RUNN_API_VERSION = os.getenv("RUNN_API_VERSION", "1.0.0")
+RUNN_CREATE_ON_HIRE = os.getenv("RUNN_CREATE_ON_HIRE", "false").lower() in ("1", "true", "yes", "on")
+RUNN_ONBOARDING_LOOKAHEAD_DAYS = int(os.getenv("RUNN_ONBOARDING_LOOKAHEAD_DAYS", "0"))
+RUNN_TIMEOFF_LOOKBACK_DAYS = int(os.getenv("RUNN_TIMEOFF_LOOKBACK_DAYS", "7"))
+RUNN_TIMEOFF_LOOKAHEAD_DAYS = int(os.getenv("RUNN_TIMEOFF_LOOKAHEAD_DAYS", "30"))
+
+
+# =========================
+# Culture Amp (SFTP)
+# =========================
+CA_SFTP_HOST = os.getenv("CA_SFTP_HOST")
+CA_SFTP_USER = os.getenv("CA_SFTP_USER")
+CA_SFTP_PASS = os.getenv("CA_SFTP_PASS")
+CA_SFTP_KEY = os.getenv("CA_SFTP_KEY")
+CA_SFTP_PASSPHRASE = os.getenv("CA_SFTP_PASSPHRASE")
+CA_SFTP_PATH = os.getenv("CA_SFTP_PATH", "/upload")
+
 
 def ch_headers():
     return {"Authorization": f"Bearer {CH_API_TOKEN}"}
 
-def tt_headers():
-    return {"Authorization": f"Token token={TT_API_KEY}",
-            "X-Api-Version": TT_API_VERSION,
-            "Content-Type": "application/vnd.api+json"}
 
-def tt_verify_signature(resource_id: str, provided_header: str):
+def tt_headers():
+    return {
+        "Authorization": f"Token token={TT_API_KEY}",
+        "X-Api-Version": TT_API_VERSION,
+        "Content-Type": "application/vnd.api+json",
+    }
+
+
+def runn_headers():
+    return {
+        "Authorization": f"Bearer {RUNN_API_TOKEN}",
+        "Accept-Version": RUNN_API_VERSION,
+        "Content-Type": "application/json",
+    }
+
+
+def tt_verify_signature(resource_id: str, provided_header: str) -> bool:
     if not TT_SIGNATURE_KEY:
         return True
     mac_hex = hmac.new(TT_SIGNATURE_KEY.encode(), resource_id.encode(), hashlib.sha256).hexdigest()
     expected = base64.b64encode(mac_hex.encode()).decode()
     return hmac.compare_digest(provided_header or "", expected)
+
+
+def strip_accents_and_non_alnum(value: str) -> str:
+    normalized = unicodedata.normalize("NFKD", (value or ""))
+    ascii_only = normalized.encode("ascii", "ignore").decode("ascii")
+    return "".join(ch for ch in ascii_only.lower() if ch.isalnum())
+
+
+def derive_locale_timezone(country_code: str) -> Tuple[str, str]:
+    if not country_code:
+        return DEFAULT_LOCALE, DEFAULT_TIMEZONE
+    cc = country_code.strip().upper()
+    locale_map = {
+        "MX": "es-MX",
+        "CR": "es-CR",
+        "CO": "es-CO",
+        "AR": "es-AR",
+        "CL": "es-CL",
+        "US": "en-US",
+        "ES": "es-ES",
+        "BR": "pt-BR",
+    }
+    tz_map = {
+        "MX": "America/Mexico_City",
+        "CR": "America/Costa_Rica",
+        "CO": "America/Bogota",
+        "AR": "America/Argentina/Buenos_Aires",
+        "CL": "America/Santiago",
+        "US": "America/Los_Angeles",
+        "ES": "Europe/Madrid",
+        "BR": "America/Sao_Paulo",
+    }
+    return locale_map.get(cc, DEFAULT_LOCALE), tz_map.get(cc, DEFAULT_TIMEZONE)
+
+
+def compose_location(state_or_city: str, country_code: str) -> str:
+    state = (state_or_city or "").strip()
+    cc = (country_code or "").strip()
+    if state and cc:
+        return f"{state}, {cc}"
+    if cc:
+        return cc
+    return state


### PR DESCRIPTION
## Summary
- reorganized configuration helpers and added env flags for ChartHop, Teamtailor, Runn and Culture Amp
- created dedicated clients and services to sync jobs, hires, Culture Amp exports and Runn onboarding/time off
- exposed cron blueprint for nightly exports and Runn automation while updating webhooks to delegate to services

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68cb6bbd74e4832588f665330c7d37fe