### PR TITLE
Handle missing Runn export module gracefully

### DIFF
--- a/app/tasks/runn_export.py
+++ b/app/tasks/runn_export.py
@@ -1,7 +1,24 @@
 # app/tasks/runn_export.py
 from flask import request, jsonify
 
-from app.services.runn_bq_export import export_runn_snapshot
+import logging
+
+try:
+    from app.services.runn_bq_export import export_runn_snapshot
+except ModuleNotFoundError as import_error:  # pragma: no cover - defensive guard
+    logging.getLogger(__name__).error(
+        "No se pudo importar app.services.runn_bq_export: %s", import_error
+    )
+
+    def export_runn_snapshot(*, window_days: int = 120):
+        """Fallback cuando el módulo opcional no está disponible."""
+
+        return {
+            "ok": False,
+            "reason": "El módulo app.services.runn_bq_export no está disponible",
+            "details": str(import_error),
+            "window_days": window_days,
+        }
 from app.tasks.ca_export import bp_tasks
 
 @bp_tasks.post("/tasks/export-runn")


### PR DESCRIPTION
## Summary
- guard the Runn export task against missing optional dependencies by logging the import failure and returning a structured fallback payload

## Testing
- python -m app.main


------
https://chatgpt.com/codex/tasks/task_e_68d5de8867d48325969d78eb7a4b5edd