### PR TITLE
Configure buildpack runtime for Python deployment

### DIFF
--- a/project.toml
+++ b/project.toml
@@ -1,0 +1,11 @@
+[project]
+id = "charthop-webhook"
+name = "Charthop Webhook"
+
+[[build.env]]
+name = "GOOGLE_RUNTIME"
+value = "python311"
+
+[[build.env]]
+name = "GOOGLE_ENTRYPOINT"
+value = "gunicorn -b :$PORT main:app"


### PR DESCRIPTION
## Summary
- add a `project.toml` descriptor so Google Cloud Buildpacks detect the Python runtime
- specify the gunicorn entrypoint that Cloud Run should use when launching the service

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68d60ca263c0832586dacad0990c3e9c