### PR TITLE
Fix Cloud Buildpack configuration for Python runtime

### DIFF
--- a/project.toml
+++ b/project.toml
@@ -4,8 +4,21 @@ name = "Charthop Webhook"
 
 [[build.env]]
 name = "GOOGLE_RUNTIME"
-value = "python311"
+value = "python"
+
+[[build.env]]
+name = "GOOGLE_RUNTIME_VERSION"
+value = "3.11"
 
 [[build.env]]
 name = "GOOGLE_ENTRYPOINT"
 value = "gunicorn -b :$PORT main:app"
+
+[[build.buildpacks]]
+id = "google.python.runtime"
+
+[[build.buildpacks]]
+id = "google.python.dependencies"
+
+[[build.buildpacks]]
+id = "google.python.gunicorn"


### PR DESCRIPTION
## Summary
- set the Google runtime to Python and specify the 3.11 version for buildpacks
- explicitly declare the Python buildpacks to prevent Go buildpack detection
- retain the gunicorn entrypoint configuration for Cloud Run deployment

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d613a526548325a7d3cb4508b8ea93