### PR TITLE
Add compatibility handlers package

### DIFF
--- a/handlers/__init__.py
+++ b/handlers/__init__.py
@@ -1,0 +1,9 @@
+"""Compatibility package for legacy import paths.
+
+This package re-exports handlers implemented under the :mod:`app.handlers`
+namespace so existing integrations that import from ``handlers`` continue to
+work without modification.
+"""
+from app.handlers.runn_to_bq import export_handler as runn_export_handler
+
+__all__ = ["runn_export_handler"]

--- a/handlers/runn_to_bq.py
+++ b/handlers/runn_to_bq.py
@@ -1,0 +1,34 @@
+"""Compatibility wrapper for the Runn to BigQuery export handler.
+
+Historically the project exposed the export handler as ``handlers.runn_to_bq``.
+The implementation now lives in :mod:`app.handlers.runn_to_bq`, so this module
+simply proxies calls to the new location.  Keeping this thin wrapper ensures
+that any external invocation (for example Google Cloud Functions) that still
+imports ``handlers.runn_to_bq`` continues to function without code changes.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from app.handlers.runn_to_bq import export_handler as _export_handler
+
+__all__ = ["export_handler"]
+
+
+def export_handler(*args: Any, **kwargs: Any) -> Any:
+    """Delegate to :func:`app.handlers.runn_to_bq.export_handler`.
+
+    Parameters
+    ----------
+    *args: Any
+        Positional arguments forwarded to the underlying handler.
+    **kwargs: Any
+        Keyword arguments forwarded to the underlying handler.
+
+    Returns
+    -------
+    Any
+        The result of :func:`app.handlers.runn_to_bq.export_handler`.
+    """
+
+    return _export_handler(*args, **kwargs)


### PR DESCRIPTION
## Summary
- add a top-level `handlers` package so legacy imports continue to resolve
- proxy `handlers.runn_to_bq.export_handler` to the implementation in `app.handlers`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6efce295083259d4b0c76735a149a