### PR TITLE
Fix modifiedAfter clamp when rewinding delta window

### DIFF
--- a/scripts/runn_sync.py
+++ b/scripts/runn_sync.py
@@ -306,7 +306,7 @@ def main():
                 since = last - dt.timedelta(minutes=OVERLAP_MINUTES)
                 if _supports_modified_after(path):
                     baseline = now - dt.timedelta(days=args.delta_days)
-                    if since > baseline:
+                    if since < baseline:
                         since = baseline
                 since_iso = since.strftime("%Y-%m-%dT%H:%M:%SZ")
             else:


### PR DESCRIPTION
## Summary
- fix the delta lookback clamp so we only truncate the modifiedAfter watermark when the last sync is older than the configured lookback window

## Testing
- python -m compileall scripts/runn_sync.py

------
https://chatgpt.com/codex/tasks/task_e_68dc8421f04483258f6add8fdd508a5c