### PR TITLE
Fix Culture Amp name fallback for missing preferred first names

### DIFF
--- a/app/clients/charthop.py
+++ b/app/clients/charthop.py
@@ -221,10 +221,12 @@ def iter_culture_amp_rows_with_ids() -> Iterator[tuple[Dict[str, str], str]]:
             first = (p.get("name.first") or "").strip()
             last = (p.get("name.last") or "").strip()
 
-            if pref_first or pref_last:
-                name = f"{pref_first} {pref_last}".strip()
+            name_first = pref_first or first
+            name_last = pref_last or last
+            if name_first or name_last:
+                name = f"{name_first} {name_last}".strip()
             else:
-                name = f"{first} {last}".strip()
+                name = ""
 
             manager_email = (p.get("manager.contact.workEmail") or "").strip()
             city = (p.get("address.city") or "").strip()


### PR DESCRIPTION
## Summary
- update Culture Amp export name generation to fall back to legal first/last names when preferred values are missing

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dded815af883258bb534a49401ca0a